### PR TITLE
open orders params made optional

### DIFF
--- a/orders.go
+++ b/orders.go
@@ -26,14 +26,18 @@ type Orders struct {
 }
 
 func (o *Orders) GetOpenOrders(market string) ([]*models.Order, error) {
-	request, err := o.client.prepareRequest(Request{
+	requestParams := Request{
 		Auth:   true,
 		Method: http.MethodGet,
 		URL:    fmt.Sprintf("%s%s", apiUrl, apiOrders),
-		Params: map[string]string{
+	}
+	if market != "" {
+		requestParams.Params = map[string]string{
 			"market": market,
-		},
-	})
+		}
+	}
+
+	request, err := o.client.prepareRequest(requestParams)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}


### PR DESCRIPTION
Sometimes I want to get open orders for all markets, so "market" shouldn't be included in params, if you include an empty string FTX returns an error that market is not found. So I changed and made it optional. 